### PR TITLE
Add Cyclone DDS ROS RMW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,16 @@ RUN apt-get update \
         ros-"$ROS_DISTRO"-xacro \
         ros-"$ROS_DISTRO"-robot-state-publisher \
         ros-"$ROS_DISTRO"-joint-state-publisher \
+        # Install Cyclone DDS ROS RMW
+        ros-"$ROS_DISTRO"-rmw-cyclonedds-cpp \
     && rm -rf /var/lib/apt/lists/*
 
 # Setup ROS workspace folder
 ENV ROS_WS /opt/ros_ws
 WORKDIR $ROS_WS
+
+# Set cyclone DDS ROS RMW
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
 # -----------------------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ WORKDIR $ROS_WS
 # Set cyclone DDS ROS RMW
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
+COPY ./cyclone_dds.xml $ROS_WS/
+
+# Configure Cyclone cfg file
+ENV CYCLONEDDS_URI=file://${ROS_WS}/cyclone_dds.xml
+
 # -----------------------------------------------------------------------
 
 FROM base AS prebuilt

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ COPY ./cyclone_dds.xml $ROS_WS/
 # Configure Cyclone cfg file
 ENV CYCLONEDDS_URI=file://${ROS_WS}/cyclone_dds.xml
 
+# Enable ROS log colorised output
+ENV RCUTILS_COLORIZED_OUTPUT=1
+
 # -----------------------------------------------------------------------
 
 FROM base AS prebuilt

--- a/av_car_description/CHANGELOG.rst
+++ b/av_car_description/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package av_car_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add Cyclone DDS 
+
 1.0.1 (2024-04-30)
 ------------------
 * Fix pkg names (`#3 <https://github.com/ipab-rad/av_car_description/issues/3>`_)

--- a/av_car_description/CHANGELOG.rst
+++ b/av_car_description/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog for package av_car_description
 
 Forthcoming
 -----------
-* Add Cyclone DDS 
+* Add Cyclone DDS ROS RMW and configure for high msg throughput
+* Avoid overriding dev and runtime images when using docker scripts
+* Allow colorised ROS log
 
 1.0.1 (2024-04-30)
 ------------------

--- a/av_car_meshes/CHANGELOG.rst
+++ b/av_car_meshes/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package av_car_meshes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add Cyclone DDS ROS RMW and configure for high msg throughput
+* Avoid overriding dev and runtime images when using docker scripts
+* Allow colorised ROS log
+
 1.0.1 (2024-04-30)
 ------------------
 * Fix pkg names (`#3 <https://github.com/ipab-rad/av_car_description/issues/3>`_)

--- a/cyclone_dds.xml
+++ b/cyclone_dds.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config
+https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+    <Domain id="any">
+        <Internal>
+            <SocketReceiveBufferSize min="10MB"/>
+        </Internal>
+    </Domain>
+</CycloneDDS>

--- a/dev.sh
+++ b/dev.sh
@@ -5,7 +5,7 @@
 
 # Build docker image up to dev stage
 DOCKER_BUILDKIT=1 docker build \
-    -t av_car_description:latest \
+    -t av_car_description:latest-dev \
     -f Dockerfile --target dev .
 
 # Run docker image with local code volumes for development
@@ -13,4 +13,4 @@ docker run -it --rm --net host \
     -v /dev/shm:/dev/shm \
     -v ./av_car_description:/opt/ros_ws/src/car_description \
     -v ./av_car_meshes:/opt/ros_ws/src/av_car_meshes \
-    av_car_description:latest
+    av_car_description:latest-dev

--- a/dev.sh
+++ b/dev.sh
@@ -11,6 +11,7 @@ DOCKER_BUILDKIT=1 docker build \
 # Run docker image with local code volumes for development
 docker run -it --rm --net host \
     -v /dev/shm:/dev/shm \
+    -v /etc/localtime:/etc/localtime:ro \
     -v ./av_car_description:/opt/ros_ws/src/car_description \
     -v ./av_car_meshes:/opt/ros_ws/src/av_car_meshes \
     av_car_description:latest-dev

--- a/runtime.sh
+++ b/runtime.sh
@@ -19,4 +19,5 @@ DOCKER_BUILDKIT=1 docker build \
 # Run docker image without volumes
 docker run -it --rm --net host \
     -v /dev/shm:/dev/shm \
+    -v /etc/localtime:/etc/localtime:ro \
     av_car_description:latest $CMD


### PR DESCRIPTION
This PR:
- Add Cyclone DDS ROS RMW support + configuration for high msg throughput (cyclone_dds.xml)
- Avoid overriding dev and runtime images using docker scripts
  for convenience
 - Set env var to allow ROS log colorised output