### PR TITLE
Use custom  robot state publisher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ros:humble-ros-base-jammy AS base
 
 # Switch to much faster mirror for apt processes
-ENV OLD_MIRROR archive.ubuntu.com
-ENV SEC_MIRROR security.ubuntu.com
-ENV NEW_MIRROR mirror.bytemark.co.uk
+ENV OLD_MIRROR=archive.ubuntu.com
+ENV SEC_MIRROR=security.ubuntu.com
+ENV NEW_MIRROR=mirror.bytemark.co.uk
 
 RUN sed -i "s/$OLD_MIRROR\|$SEC_MIRROR/$NEW_MIRROR/g" /etc/apt/sources.list
 
@@ -18,7 +18,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Setup ROS workspace folder
-ENV ROS_WS /opt/ros_ws
+ENV ROS_WS=/opt/ros_ws
 WORKDIR $ROS_WS
 
 # Set cyclone DDS ROS RMW
@@ -33,7 +33,9 @@ ENV CYCLONEDDS_URI=file://${ROS_WS}/cyclone_dds.xml
 ENV RCUTILS_COLORIZED_OUTPUT=1
 
 # Clone custom robot state_publisher
-RUN git clone -b remove-static-tf-pub https://github.com/ipab-rad/robot_state_publisher.git "$ROS_WS"/src/robot_state_publisher
+RUN git clone -b tartan-humble \
+    https://github.com/ipab-rad/robot_state_publisher.git \
+    "$ROS_WS"/src/robot_state_publisher
 
 # -----------------------------------------------------------------------
 
@@ -74,7 +76,7 @@ CMD ["bash"]
 
 # -----------------------------------------------------------------------
 
-FROM base as runtime
+FROM base AS runtime
 
 # Copy artifacts/binaries from prebuilt
 COPY --from=prebuilt $ROS_WS/install $ROS_WS/install

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
         apt-get -y --quiet --no-install-recommends install \
         ros-"$ROS_DISTRO"-xacro \
-        ros-"$ROS_DISTRO"-robot-state-publisher \
         ros-"$ROS_DISTRO"-joint-state-publisher \
         # Install Cyclone DDS ROS RMW
         ros-"$ROS_DISTRO"-rmw-cyclonedds-cpp \
@@ -32,6 +31,9 @@ ENV CYCLONEDDS_URI=file://${ROS_WS}/cyclone_dds.xml
 
 # Enable ROS log colorised output
 ENV RCUTILS_COLORIZED_OUTPUT=1
+
+# Clone custom robot state_publisher
+RUN git clone -b remove-static-tf-pub https://github.com/ipab-rad/robot_state_publisher.git "$ROS_WS"/src/robot_state_publisher
 
 # -----------------------------------------------------------------------
 

--- a/av_car_description/CHANGELOG.rst
+++ b/av_car_description/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package av_car_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update `robot_state_publisher` pkg to `ipab-rad` version for continously
+  publish `tf_static`.
+
+* Contributors: hect95
+
 1.3.0 (2024-06-24)
 ------------------
 * Prepend all sensor/optical frames with `camera\_`

--- a/av_car_description/launch/car_description.launch.xml
+++ b/av_car_description/launch/car_description.launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <node name="robot_state_publisher" pkg="robot_state_publisher" exec="robot_state_publisher">
     <param name='robot_description' type="str" value="$(command 'xacro $(find-pkg-share av_car_description)/urdf/mondeo_dca/mondeo_dca.xacro')"/>
+    <param name='publish_frequency' value="20.0"/>
   </node>
 
   <node pkg="joint_state_publisher" exec="joint_state_publisher" name="joint_state_publisher"/>

--- a/av_car_description/launch/car_description.launch.xml
+++ b/av_car_description/launch/car_description.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <node name="robot_state_publisher" pkg="robot_state_publisher" exec="robot_state_publisher">
     <param name='robot_description' type="str" value="$(command 'xacro $(find-pkg-share av_car_description)/urdf/mondeo_dca/mondeo_dca.xacro')"/>
-    <param name='publish_frequency' value="20.0"/>
+    <param name='static_publish_frequency' value="10.0"/>
   </node>
 
   <node pkg="joint_state_publisher" exec="joint_state_publisher" name="joint_state_publisher"/>

--- a/av_car_meshes/CHANGELOG.rst
+++ b/av_car_meshes/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package av_car_meshes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update `robot_state_publisher` package to the `ipab-rad` version to 
+  continuously publish `tf_static` topic
+
+* Contributors: hect95
+
 1.3.0 (2024-06-24)
 ------------------
 * Prepend all sensor/optical frames with `camera\_`


### PR DESCRIPTION
- Update the `robot_state_publisher` ROS package for the `ipab-rad` version, implementing the publishing of `tf_static` at a specified frequency.
- Fix Dockerfile linting warnings.