### PR TITLE
Update lidars extrinsics

### DIFF
--- a/av_car_description/CHANGELOG.rst
+++ b/av_car_description/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package av_car_description
 
 Forthcoming
 -----------
-* Add calibrated lidar extrniscs between:
+* Add calibrated lidar extrinsics between:
   * lidar_ouster_top -> lidar_left
   * lidar_ouster_top -> lidar_right
 * Contributors: Hector Cruz, hect95

--- a/av_car_description/CHANGELOG.rst
+++ b/av_car_description/CHANGELOG.rst
@@ -4,9 +4,15 @@ Changelog for package av_car_description
 
 Forthcoming
 -----------
-* Add calibrated lidar extrinsics between:
-  * lidar_ouster_top -> lidar_left
-  * lidar_ouster_top -> lidar_right
+* Refactor LIDAR mounting structure based on LIDAR calibration.
+  - Perform adjustments based on calibration between `lidar_ouster_top` and both `lidar_left`
+    and `lidar_right`.
+    - Update the old chain: `vehicle_roof_datum -> lidar_left` and 
+      `vehicle_roof_datum -> lidar_right` to:
+      - `vehicle_roof_datum -> lidar_left_mount -> lidar_left`
+      - `vehicle_roof_datum -> lidar_right_mount -> lidar_right`
+  - Ensure that the new chain `vehicle_roof_datum -> lidar_x_mount` matches 
+    the old `vehicle_roof_datum -> lidar_x` TF for future reference.
 * Contributors: Hector Cruz, hect95
 
 1.5.1 (2024-10-07)

--- a/av_car_description/CHANGELOG.rst
+++ b/av_car_description/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package av_car_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add calibrated lidar extrniscs between:
+  * lidar_ouster_top -> lidar_left
+  * lidar_ouster_top -> lidar_right
+* Contributors: Hector Cruz, hect95
+
 1.5.1 (2024-10-07)
 ------------------
 * Update fsp_l camera tf (`#17 <https://github.com/ipab-rad/av_car_description/issues/17>`_)

--- a/av_car_description/urdf/mondeo_dca/mondeo_dca_sensors.xacro
+++ b/av_car_description/urdf/mondeo_dca/mondeo_dca_sensors.xacro
@@ -196,21 +196,29 @@
     <origin xyz="-0.66015 0 0.19758" rpy="0 0 0"/>
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_left_old" parent="${roof_datum}">
+  <xacro:lidar name="lidar_left_no_calib" parent="${roof_datum}">
     <origin xyz="-0.03015 0.720 -0.22242" rpy="-0.087266 0.087266 0.6562438"/>
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_left" parent="vehicle_roof_datum">
+  <xacro:lidar name="lidar_left_calib_v1" parent="vehicle_roof_datum">
     <origin xyz="0.0107329 0.728872 -0.116884" rpy="-0.0388081 0.102642 0.65186" />
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_right_old" parent="${roof_datum}">
+  <xacro:lidar name="lidar_left" parent="vehicle_roof_datum">
+    <origin xyz="0.0124227 0.727969 -0.112672" rpy="-0.037683 0.102063 0.651836" />
+  </xacro:lidar>
+
+  <xacro:lidar name="lidar_right_no_calib" parent="${roof_datum}">
     <origin xyz="-0.03015 -0.720 -0.22242" rpy="0.087266 0.087266 -0.6562438"/>
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_right" parent="vehicle_roof_datum">
+  <xacro:lidar name="lidar_right_calib_v1" parent="vehicle_roof_datum">
     <origin xyz="-0.0115331 -0.705366 -0.133119" rpy="0.026757 0.0875472 -0.655852" />
   </xacro:lidar>
+
+  <xacro:lidar name="lidar_right" parent="vehicle_roof_datum">
+    <origin xyz="-0.00715063 -0.714411 -0.160957" rpy="0.0316876 0.0944851 -0.655334" />
+  </xacro:lidar>  
 
   <xacro:lidar name="lidar_ouster_top" parent="${roof_datum}">
     <origin xyz="-0.65855 0 0.21849" rpy="0 -0.017453 0"/>

--- a/av_car_description/urdf/mondeo_dca/mondeo_dca_sensors.xacro
+++ b/av_car_description/urdf/mondeo_dca/mondeo_dca_sensors.xacro
@@ -196,12 +196,20 @@
     <origin xyz="-0.66015 0 0.19758" rpy="0 0 0"/>
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_left" parent="${roof_datum}">
+  <xacro:lidar name="lidar_left_old" parent="${roof_datum}">
     <origin xyz="-0.03015 0.720 -0.22242" rpy="-0.087266 0.087266 0.6562438"/>
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_right" parent="${roof_datum}">
+  <xacro:lidar name="lidar_left" parent="vehicle_roof_datum">
+    <origin xyz="0.0107329 0.728872 -0.116884" rpy="-0.0388081 0.102642 0.65186" />
+  </xacro:lidar>
+
+  <xacro:lidar name="lidar_right_old" parent="${roof_datum}">
     <origin xyz="-0.03015 -0.720 -0.22242" rpy="0.087266 0.087266 -0.6562438"/>
+  </xacro:lidar>
+
+  <xacro:lidar name="lidar_right" parent="vehicle_roof_datum">
+    <origin xyz="-0.0115331 -0.705366 -0.133119" rpy="0.026757 0.0875472 -0.655852" />
   </xacro:lidar>
 
   <xacro:lidar name="lidar_ouster_top" parent="${roof_datum}">

--- a/av_car_description/urdf/mondeo_dca/mondeo_dca_sensors.xacro
+++ b/av_car_description/urdf/mondeo_dca/mondeo_dca_sensors.xacro
@@ -196,29 +196,13 @@
     <origin xyz="-0.66015 0 0.19758" rpy="0 0 0"/>
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_left_no_calib" parent="${roof_datum}">
-    <origin xyz="-0.03015 0.720 -0.22242" rpy="-0.087266 0.087266 0.6562438"/>
+  <xacro:lidar name="lidar_left" parent="${roof_datum}">
+    <origin xyz="0.0124227 0.727969 -0.112672" rpy="-0.037683 0.102063 0.651836"/>
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_left_calib_v1" parent="vehicle_roof_datum">
-    <origin xyz="0.0107329 0.728872 -0.116884" rpy="-0.0388081 0.102642 0.65186" />
+  <xacro:lidar name="lidar_right" parent="${roof_datum}">
+    <origin xyz="-0.00715063 -0.714411 -0.160957" rpy="0.0316876 0.0944851 -0.655334"/>
   </xacro:lidar>
-
-  <xacro:lidar name="lidar_left" parent="vehicle_roof_datum">
-    <origin xyz="0.0124227 0.727969 -0.112672" rpy="-0.037683 0.102063 0.651836" />
-  </xacro:lidar>
-
-  <xacro:lidar name="lidar_right_no_calib" parent="${roof_datum}">
-    <origin xyz="-0.03015 -0.720 -0.22242" rpy="0.087266 0.087266 -0.6562438"/>
-  </xacro:lidar>
-
-  <xacro:lidar name="lidar_right_calib_v1" parent="vehicle_roof_datum">
-    <origin xyz="-0.0115331 -0.705366 -0.133119" rpy="0.026757 0.0875472 -0.655852" />
-  </xacro:lidar>
-
-  <xacro:lidar name="lidar_right" parent="vehicle_roof_datum">
-    <origin xyz="-0.00715063 -0.714411 -0.160957" rpy="0.0316876 0.0944851 -0.655334" />
-  </xacro:lidar>  
 
   <xacro:lidar name="lidar_ouster_top" parent="${roof_datum}">
     <origin xyz="-0.65855 0 0.21849" rpy="0 -0.017453 0"/>

--- a/av_car_description/urdf/mondeo_dca/mondeo_dca_sensors.xacro
+++ b/av_car_description/urdf/mondeo_dca/mondeo_dca_sensors.xacro
@@ -192,16 +192,20 @@
   </xacro:gps>
 
   <!-- LIDAR -->
-  <xacro:lidar name="lidar_top" parent="${roof_datum}">
-    <origin xyz="-0.66015 0 0.19758" rpy="0 0 0"/>
+  <xacro:lidar name="lidar_left_mount" parent="${roof_datum}">
+    <origin xyz="-0.03015 0.720 -0.22242" rpy="-0.087266 0.087266 0.6562438"/>
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_left" parent="${roof_datum}">
-    <origin xyz="0.0124227 0.727969 -0.112672" rpy="-0.037683 0.102063 0.651836"/>
+  <xacro:lidar name="lidar_left" parent="lidar_left_mount">
+    <origin xyz="0.0288801 -0.0294088 0.110552" rpy="0.0499763 0.0151241 -0.00307838"/>
   </xacro:lidar>
 
-  <xacro:lidar name="lidar_right" parent="${roof_datum}">
-    <origin xyz="-0.00715063 -0.714411 -0.160957" rpy="0.0316876 0.0944851 -0.655334"/>
+  <xacro:lidar name="lidar_right_mount" parent="${roof_datum}">
+    <origin xyz="-0.03015 -0.720 -0.22242" rpy="0.087266 0.087266 -0.6562438"/>
+  </xacro:lidar>
+
+  <xacro:lidar name="lidar_right" parent="lidar_right_mount">
+    <origin xyz="0.00939891 0.0238397 0.0606727" rpy="-0.0556599 0.00727062 0.000273152"/>
   </xacro:lidar>
 
   <xacro:lidar name="lidar_ouster_top" parent="${roof_datum}">

--- a/av_car_meshes/CHANGELOG.rst
+++ b/av_car_meshes/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package av_car_meshes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add calibrated lidar extrniscs between:
+  * lidar_ouster_top -> lidar_left
+  * lidar_ouster_top -> lidar_right
+* Contributors: Hector Cruz, hect95
+
 1.5.1 (2024-10-07)
 ------------------
 * Update fsp_l camera tf (`#17 <https://github.com/ipab-rad/av_car_description/issues/17>`_)

--- a/av_car_meshes/CHANGELOG.rst
+++ b/av_car_meshes/CHANGELOG.rst
@@ -4,9 +4,15 @@ Changelog for package av_car_meshes
 
 Forthcoming
 -----------
-* Add calibrated lidar extrinsics between:
-  * lidar_ouster_top -> lidar_left
-  * lidar_ouster_top -> lidar_right
+* Refactor LIDAR mounting structure based on LIDAR calibration.
+  - Perform adjustments based on calibration between `lidar_ouster_top` and both `lidar_left`
+    and `lidar_right`.
+    - Update the old chain: `vehicle_roof_datum -> lidar_left` and 
+      `vehicle_roof_datum -> lidar_right` to:
+      - `vehicle_roof_datum -> lidar_left_mount -> lidar_left`
+      - `vehicle_roof_datum -> lidar_right_mount -> lidar_right`
+  - Ensure that the new chain `vehicle_roof_datum -> lidar_x_mount` matches 
+    the old `vehicle_roof_datum -> lidar_x` TF for future reference.
 * Contributors: Hector Cruz, hect95
 
 1.5.1 (2024-10-07)

--- a/av_car_meshes/CHANGELOG.rst
+++ b/av_car_meshes/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package av_car_meshes
 
 Forthcoming
 -----------
-* Add calibrated lidar extrniscs between:
+* Add calibrated lidar extrinsics between:
   * lidar_ouster_top -> lidar_left
   * lidar_ouster_top -> lidar_right
 * Contributors: Hector Cruz, hect95


### PR DESCRIPTION
* Refactor LIDAR mounting structure based on LIDAR calibration.
  - Perform adjustments based on calibration between `lidar_ouster_top` and both `lidar_left`
    and `lidar_right`.
    - Update the old chain: `vehicle_roof_datum -> lidar_left` and 
      `vehicle_roof_datum -> lidar_right` to:
      - `vehicle_roof_datum -> lidar_left_mount -> lidar_left`
      - `vehicle_roof_datum -> lidar_right_mount -> lidar_right`
  - Ensure that the new chain `vehicle_roof_datum -> lidar_x_mount` matches 
    the old `vehicle_roof_datum -> lidar_x` TF for future reference.